### PR TITLE
Added automatic docker image builds with github actions

### DIFF
--- a/.github/workflows/flixor-docker-build.yml
+++ b/.github/workflows/flixor-docker-build.yml
@@ -111,7 +111,7 @@ jobs:
         id: build-frontend
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ./web_frontend
           file: ./web_frontend/docker/frontend.Dockerfile
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Your current docker image only supported arm devices and I wanted to run this in an x64 system. 


Github action currently builds a docker image for the front and back-end's and publishes them to the packages space. Currently pretty basic but can be easily changed to support whatever release plan you want to have in the future.